### PR TITLE
Fix for Undefined Behaviour

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,11 @@ if (NOT PYTHON_VERSION VERSION_LESS 3.0)
   error("Requires python 2.x")
 endif()
 
-find_package(Boost COMPONENTS unit_test_framework)
+option( WRAPPY_BUILD_DEMOS "Build the wrappy tests" ON)
+
+if (WRAPPY_BUILD_DEMOS)
+  find_package(Boost COMPONENTS unit_test_framework)
+endif()
 
 # wrappy library target
 add_library(wrappy SHARED wrappy.cpp)
@@ -38,7 +42,7 @@ target_link_libraries(example_turtle wrappy)
 target_link_libraries(example_plot wrappy)
 
 # Tests
-if(Boost_UNIT_TEST_FRAMEWORK_FOUND)
+if(WRAPPY_BUILD_DEMOS AND Boost_UNIT_TEST_FRAMEWORK_FOUND)
   enable_testing()
   add_executable(test_stdlib tests/stdlib.cpp)
   add_executable(test_sugar tests/sugar.cpp)

--- a/wrappy.cpp
+++ b/wrappy.cpp
@@ -92,8 +92,8 @@ PythonObject loadObject(PythonObject module, const std::string& name)
     size_t suffixDot = 0;
     while(suffixDot != std::string::npos) {
         size_t next_dot = name.find('.', suffixDot+1);
-        auto attr = name.substr(suffixDot+1, next_dot-(suffixDot+1)).c_str();
-        object = PythonObject(PythonObject::owning {}, PyObject_GetAttrString(object.get(), attr));
+        auto attr = name.substr(suffixDot+1, next_dot - (suffixDot+1));
+        object = PythonObject(PythonObject::owning {}, PyObject_GetAttrString(object.get(), attr.c_str()));
         suffixDot = next_dot;
     }
 


### PR DESCRIPTION
Using the value returned by c_str() after the destruction of the std::string is undefined behaviour. On GCC 6.3.1 this prevents loading of objects as I believe the destructor zeros out the string.