### PR TITLE
Add optional support for Python 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,8 @@ cmake_minimum_required (VERSION 2.8)
 project (wrappy)
 
 # Dependencies
-find_package(PythonLibs 2.7 REQUIRED)
-# If i had one word to describe python versioning,
-# it would be "broken as fuck"
-if (NOT PYTHON_VERSION VERSION_LESS 3.0)
-  error("Requires python 2.x")
-endif()
+# If PYTHON_VERSION isn't set, use the default version on this system
+find_package(PythonLibs ${PYTHON_VERSION} REQUIRED)
 
 option( WRAPPY_BUILD_DEMOS "Build the wrappy tests" ON)
 
@@ -20,7 +16,7 @@ add_library(wrappy SHARED wrappy.cpp)
 set_target_properties(wrappy PROPERTIES VERSION 1.0.0)
 set_target_properties(wrappy PROPERTIES SOVERSION 1)
 
-target_include_directories(wrappy PRIVATE ${PYTHON_INCLUDE_DIRS})
+include_directories(wrappy PUBLIC ${PYTHON_INCLUDE_DIRS})
 target_include_directories(wrappy PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include/)
 
 if(${CMAKE_VERSION} VERSION_LESS 3.1)

--- a/tests/stdlib.cpp
+++ b/tests/stdlib.cpp
@@ -32,8 +32,10 @@ BOOST_AUTO_TEST_CASE(builtins)
     args[0] = wrappy::construct(255ll);
     auto longval = wrappy::callWithArgs("hex", args);
 
-    BOOST_CHECK_EQUAL(intval.str(), "0xff");
-    BOOST_CHECK_EQUAL(longval.str(), "0xffL");
+    std::string intval_str = intval.str();
+    std::string longval_str = longval.str();
+    BOOST_TEST(intval.str() == "0xff");
+    BOOST_TEST(longval.str() == "0xffL");
 }
 
 BOOST_AUTO_TEST_CASE(error)


### PR DESCRIPTION
This PR adds Python 3 support. By default, the system version of ``PythonLibs`` is used, but I can set it to use v2.7 by default instead.

Mostly it was just a case of replacing ``Py*`` functions with their Python 3 counterparts, but there were a couple of semantic changes I had to make to make things work with Python 3:
* Strings are encoded as Unicode in Python 3, so use ``wchar_t`` internally. Rather than returning ``wchar_t`` from ``str()`` I opted to convert it to UTF8 and return a ``std::string`` for the Python 3 version (needed because you have to copy the memory). Likewise ``std::map<char *, ...>`` has been changed to use ``std::string`` in a few places. I could have just replaced uses of ``char *`` with ``std::string`` for Python 2 but that would have broken the API for existing users -- you could do this for consistency in some future version though. This change also means that ``Python.h`` has to be included in ``wrappy.h`` so that it knows what the return type for ``str()`` should be.
* CObjects have been replaced with Capsules in Python 3, so I use those instead. I *think* what I've done should be equivalent.