### PR TITLE
Add option to build as static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,13 @@ if (WRAPPY_BUILD_DEMOS)
   find_package(Boost COMPONENTS unit_test_framework)
 endif()
 
+# Default to making a shared lib
+if(NOT DEFINED WRAPPY_LIBRRARY_TYPE)
+  set(WRAPPY_LIBRRARY_TYPE SHARED)
+endif()
+
 # wrappy library target
-add_library(wrappy SHARED wrappy.cpp)
+add_library(wrappy ${WRAPPY_LIBRRARY_TYPE} wrappy.cpp)
 set_target_properties(wrappy PROPERTIES VERSION 1.0.0)
 set_target_properties(wrappy PROPERTIES SOVERSION 1)
 


### PR DESCRIPTION
This PR adds the option to build wrappy as a static library, which fits my use case better. It still defaults to building a shared library, if it hasn't been explicitly stated by setting ``WRAPPY_LIBRARY_TYPE``.